### PR TITLE
feat(header): Add searchbar to header

### DIFF
--- a/src/scss/search.scss
+++ b/src/scss/search.scss
@@ -1,0 +1,54 @@
+.seneca-navbar .seneca-search {
+  position: relative;
+  display: table;
+  padding:15px 0px 0px 0px;
+  border-bottom: 2px solid #333;
+  margin: 0 auto;
+  width: 200px;
+  &:before {
+    content: "\f002";
+    display: table-cell;
+    color: #333;
+    vertical-align: middle;
+    font-family: "FontAwesome";
+    text-align: center;
+    width: 30px;
+  }
+}
+
+.seneca-navbar .seneca-search--input {
+  width: 170px;
+  display: table-cell;
+  margin: 0 auto;
+  font-weight: normal;
+  box-shadow: none;
+  border-color: transparent;
+  background-color: transparent;
+  &:focus {
+    outline: 0;
+    box-shadow: none;
+    border: 0px;
+  }
+}
+
+// Screen big enough to display all menu elements, but still too small to
+// display the search input.
+@media (min-width: 768px) {
+  .seneca-navbar .seneca-search {
+    display: none;
+  }
+}
+
+// Screen big enough to display the search input alongside the menu
+@media (min-width: 1280px) {
+  .seneca-navbar .seneca-search {
+    display: table;
+  }
+  .seneca-navbar .seneca-search {
+    width: 300px;
+  }
+  .seneca-navbar .seneca-search--input {
+    margin: 0px;
+    width: 270px;
+  }
+}

--- a/src/template/partials/head.html
+++ b/src/template/partials/head.html
@@ -8,5 +8,6 @@
 <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css" />
 <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.0.0/styles/default.min.css">
 <link rel="stylesheet" href="/stylesheets/style.css" />
+<link rel="stylesheet" href="/stylesheets/search.css" />
 
 <title>Seneca, a microservices toolkit for Node.js</title>

--- a/src/template/partials/menu.html
+++ b/src/template/partials/menu.html
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-default navbar-fixed-top" role="navigation">
+<nav class="navbar navbar-default navbar-fixed-top seneca-navbar" role="navigation">
   <div class="navbar-960">
     <div class="navbar-header">
       <a class="navbar-brand" href="/">
@@ -7,6 +7,9 @@
       </a>
     </div>
     <ul class="nav navbar-nav navbar-right">
+      <li class="navbar-font seneca-search">
+        <input type="text" class="form-control seneca-search--input" placeholder="Search the docs...">
+      </li>
       <li class="navbar-font"><a href='/get-started/'>Getting started</a></li>
       <li class="navbar-font"><a href='/tutorials/'>Tutorials</a></li>
       <li class="navbar-font"><a href='/faq.html'>FAQ</a></li>


### PR DESCRIPTION
I've added a search input to the top bar. I haven't added DocSearch or any Javascript, I'll let you handle that.

On medium screens, I've decided to completly hide the searchbar because the design wasn't really allowing for adding it. I only added it for small mobile screens and big desktop one.
![image](https://cloud.githubusercontent.com/assets/283419/12713202/9bfe13a2-c8cd-11e5-9415-2555c0a03e34.png)
![image](https://cloud.githubusercontent.com/assets/283419/12713212/a2d391ca-c8cd-11e5-9e97-74dc80d1ce3d.png)
![image](https://cloud.githubusercontent.com/assets/283419/12713222/a9d4ecb2-c8cd-11e5-89d3-c37e6922d68d.png)
![image](https://cloud.githubusercontent.com/assets/283419/12713229/af94d018-c8cd-11e5-8da8-fa5fb348a7cf.png)

Hope you'll like it. Tell me if you need anything else.

Cheers,
